### PR TITLE
meta tags are for iOs safari

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -23,7 +23,7 @@
 
   <head>
     <title>Golo Web Console</title>
-
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">


### PR DESCRIPTION
allow full screen webapp to the home screen
